### PR TITLE
fix: Replace Object with SS_Object as required for PHP 7.2+ support.

### DIFF
--- a/code/services/IPLoggerService.php
+++ b/code/services/IPLoggerService.php
@@ -6,7 +6,7 @@
  * @package silverstripe-iplogger
  * @see https://docs.silverstripe.org/en/3.1/developer_guides/extending/injector/
  */
-class IPLoggerService extends Object
+class IPLoggerService extends SS_Object
 {
     private static $rules = array();
 


### PR DESCRIPTION
As of PHP 7.2, `object` is a reserved keyword. Extending SS_Object instead of Object resolves the issue.